### PR TITLE
fix pluralization in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ import pypd
 pypd.api_key = "SOMESECRETAPIKEY"
 
 # fetch some dataz
-incidents = pypd.Incidents.find(maximum=10)
+incidents = pypd.Incident.find(maximum=10)
 
 # how do dataz?
 ep = pypd.EscalationPolicy.find_one()


### PR DESCRIPTION
The example includes `incidents = pypd.Incidents.find(maximum=10)`, but the pluralization is wrong, it's `Incident` not `Incidents`.
